### PR TITLE
Fix example client usage

### DIFF
--- a/day1/03_FastAPI/python-client.py
+++ b/day1/03_FastAPI/python-client.py
@@ -79,9 +79,9 @@ if __name__ == "__main__":
     
     # 単一の質問
     print("Simple question:")
-    result = client.generate([
-        {"prompt": "AIについて100文字で教えてください"}
-    ])
+    result = client.generate(
+        "AIについて100文字で教えてください"
+    )
     print(f"Response: {result['generated_text']}")
     print(f"Model processing time: {result['response_time']:.2f}s")
     print(f"Total request time: {result['total_request_time']:.2f}s")    


### PR DESCRIPTION
## Summary
- update python client example to pass prompt as string instead of list

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_683fb42090a08322bab6ebe782c90300